### PR TITLE
Restructure + fixing open issues

### DIFF
--- a/DataDude.Tests/Core/Scripts/Migrations/1.0.0/01.Schema.sql
+++ b/DataDude.Tests/Core/Scripts/Migrations/1.0.0/01.Schema.sql
@@ -58,6 +58,12 @@ CREATE TABLE Test_Generated_PK_Scenario_2(
 )
 GO
 
+CREATE TABLE Test_PK_Less_Scenario(
+	Id1 INT NOT NULL,
+	Id2 INT NOT NULL,
+)
+GO
+
 CREATE TRIGGER People.EmployeeUpdatedAt ON People.Employee AFTER UPDATE AS BEGIN
 	UPDATE People.Employee 
 		SET People.Employee.UpdatedAt = GETDATE()

--- a/DataDude.Tests/Core/TestSchema.cs
+++ b/DataDude.Tests/Core/TestSchema.cs
@@ -1,19 +1,28 @@
-﻿using DataDude.Schema;
+﻿using System.Data;
+using System.Threading.Tasks;
+using DataDude.Schema;
 
 namespace DataDude.Tests.Core
 {
-    public class TestSchema : SchemaInformation
+    public class TestSchema : SchemaInformation, ISchemaLoader
     {
         public TestSchema()
             : base(new TableInformation[0])
         {
         }
 
+        public bool CacheSchema { get; set; }
+
         public TestTable AddTable(string name)
         {
             var table = new TestTable(name);
             Tables.Add(name, table);
             return table;
+        }
+
+        public Task<SchemaInformation> Load(IDbConnection connection, IDbTransaction transaction = null)
+        {
+            return Task.FromResult(this as SchemaInformation);
         }
     }
 }

--- a/DataDude.Tests/DataDude.Tests.csproj
+++ b/DataDude.Tests/DataDude.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ADatabaseFixture.GalacticWasteManagement" Version="0.2.1" />
     <PackageReference Include="ADatabaseFixture.SqlServer" Version="0.1.0" />
+    <PackageReference Include="FakeItEasy" Version="6.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Respawn" Version="3.3.0" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0004" />

--- a/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
+++ b/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
@@ -19,8 +19,8 @@ namespace DataDude.Tests.Inserts
             var b = schema.AddTable("B").AddFk(a);
             var c = schema.AddTable("C").AddFk(b);
 
-            var context = new DataDudeContext() { Schema = schema };
-
+            var context = new DataDudeContext(schema);
+            await context.LoadSchema(null, null);
             context.Instructions.Add(new InsertInstruction("C"));
             var dependencyService = new DependencyService(DependencyTraversalStrategy.FollowAllForeignKeys);
             await new AddMissingInsertInstructionsPreProcessor(dependencyService).PreProcess(context);
@@ -39,8 +39,8 @@ namespace DataDude.Tests.Inserts
             var c = schema.AddTable("C").AddFk(b);
             var d = schema.AddTable("D").AddFk(c);
 
-            var context = new DataDudeContext() { Schema = schema };
-
+            var context = new DataDudeContext(schema);
+            await context.LoadSchema(null, null);
             context.Instructions.Add(new InsertInstruction("B"));
             context.Instructions.Add(new InsertInstruction("D"));
             var dependencyService = new DependencyService(DependencyTraversalStrategy.FollowAllForeignKeys);
@@ -60,8 +60,8 @@ namespace DataDude.Tests.Inserts
             var c = schema.AddTable("C").AddFk(b);
             var d = schema.AddTable("D").AddFk(c);
 
-            var context = new DataDudeContext() { Schema = schema };
-
+            var context = new DataDudeContext(schema);
+            await context.LoadSchema(null, null);
             context.Instructions.Add(new InsertInstruction("A"));
             context.Instructions.Add(new InsertInstruction("D"));
             var dependencyService = new DependencyService(DependencyTraversalStrategy.FollowAllForeignKeys);
@@ -80,8 +80,8 @@ namespace DataDude.Tests.Inserts
             a.AddForeignKey(t => new ForeignKeyInformation("FK_A_A", t, t, new[] { (t["Id"], t["Id"]) }));
             var b = schema.AddTable("B").AddFk(a);
 
-            var context = new DataDudeContext() { Schema = schema };
-
+            var context = new DataDudeContext(schema);
+            await context.LoadSchema(null, null);
             context.Instructions.Add(new InsertInstruction("B"));
             var dependencyService = new DependencyService(DependencyTraversalStrategy.SkipRecursiveForeignKeys);
             await new AddMissingInsertInstructionsPreProcessor(dependencyService).PreProcess(context);
@@ -102,8 +102,8 @@ namespace DataDude.Tests.Inserts
             });
             b.AddForeignKey(t => new ForeignKeyInformation("FK_B_A", t, a, new[] { (t["a_Id"], a["Id"]) }));
 
-            var context = new DataDudeContext() { Schema = schema };
-
+            var context = new DataDudeContext(schema);
+            await context.LoadSchema(null, null);
             context.Instructions.Add(new InsertInstruction("B"));
             var dependencyService = new DependencyService(DependencyTraversalStrategy.SkipNullableForeignKeys);
             await new AddMissingInsertInstructionsPreProcessor(dependencyService).PreProcess(context);

--- a/DataDude.Tests/Schema/SchemaCachingTests.cs
+++ b/DataDude.Tests/Schema/SchemaCachingTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Data;
+using System.Threading.Tasks;
+using DataDude.Schema;
+using FakeItEasy;
+using Shouldly;
+using Xunit;
+
+namespace DataDude.Tests.Schema
+{
+    public class SchemaCachingTests
+    {
+        [Fact]
+        public async Task Schema_Can_Be_Loaded()
+        {
+            var loader = A.Fake<ISchemaLoader>();
+            var expectedSchema = new SchemaInformation(new TableInformation[0]);
+            A.CallTo(() => loader.Load(A<IDbConnection>.Ignored, A<IDbTransaction>.Ignored)).Returns(expectedSchema);
+            var dude = new Dude(loader);
+
+            await dude.Go(null, null);
+
+            dude.Configure(context => context.Schema.ShouldBe(expectedSchema));
+        }
+
+        [Fact]
+        public async Task Schema_Can_Be_Cached()
+        {
+            var schemaLoader = A.Fake<ISchemaLoader>(o => o.ConfigureFake(loader => loader.CacheSchema = true));
+
+            var dude = new Dude(schemaLoader);
+            await dude.Go(null, null);
+            await dude.Go(null, null);
+
+            A.CallTo(() => schemaLoader.Load(A<IDbConnection>.Ignored, A<IDbTransaction>.Ignored)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Schema_Cache_Can_Be_Turned_Off()
+        {
+            var schemaLoader = A.Fake<ISchemaLoader>(o => o.ConfigureFake(loader => loader.CacheSchema = true));
+            var dude = new Dude(schemaLoader);
+
+            await dude.Go(null, null);
+            await dude.Go(null, null);
+            dude.Configure(x => x.SchemaLoader.CacheSchema = false);
+            await dude.Go(null, null);
+
+            A.CallTo(() => schemaLoader.Load(A<IDbConnection>.Ignored, A<IDbTransaction>.Ignored)).MustHaveHappenedTwiceExactly();
+        }
+    }
+}

--- a/DataDude.Tests/Schema/SchemaIntegrationTests.cs
+++ b/DataDude.Tests/Schema/SchemaIntegrationTests.cs
@@ -14,13 +14,18 @@ namespace DataDude.Tests.Schema
         }
 
         [Fact]
+        public void SqlServerSchemaLoader_Has_Caching_Enabled_By_Default()
+        {
+            var loader = new SqlServerSchemaLoader();
+            loader.CacheSchema.ShouldBeTrue();
+        }
+
+        [Fact]
         public async Task Schema_Loading()
         {
             using var connection = Fixture.CreateNewConnection();
-            var loader = new SqlServerSchemaLoader();
-            var schema = await loader.Load(connection);
+            var schema = await new SqlServerSchemaLoader().Load(connection);
 
-            loader.CacheSchema.ShouldBeTrue();
             schema["Office"].ShouldNotBeNull();
             schema["Buildings.Office"].ShouldNotBeNull();
             schema["Employee"].ShouldSatisfyAllConditions(

--- a/DataDude.Tests/Schema/SchemaIntegrationTests.cs
+++ b/DataDude.Tests/Schema/SchemaIntegrationTests.cs
@@ -4,11 +4,11 @@ using DataDude.Tests.Core;
 using Shouldly;
 using Xunit;
 
-namespace DataDude.Tests
+namespace DataDude.Tests.Schema
 {
-    public class SchemaTests : DatabaseTest
+    public class SchemaIntegrationTests : DatabaseTest
     {
-        public SchemaTests(DatabaseFixture fixture)
+        public SchemaIntegrationTests(DatabaseFixture fixture)
             : base(fixture)
         {
         }
@@ -17,9 +17,10 @@ namespace DataDude.Tests
         public async Task Schema_Loading()
         {
             using var connection = Fixture.CreateNewConnection();
+            var loader = new SqlServerSchemaLoader();
+            var schema = await loader.Load(connection);
 
-            var schema = await new SqlServerSchemaLoader().Load(connection);
-
+            loader.CacheSchema.ShouldBeTrue();
             schema["Office"].ShouldNotBeNull();
             schema["Buildings.Office"].ShouldNotBeNull();
             schema["Employee"].ShouldSatisfyAllConditions(

--- a/DataDude/DataDude.csproj
+++ b/DataDude/DataDude.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>0.4.0</Version>
+    <Version>0.4.0-beta.8</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/DataDude/DataDude.csproj
+++ b/DataDude/DataDude.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>0.4.0-beta.8</Version>
+    <Version>0.4.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/DataDude/Dude.cs
+++ b/DataDude/Dude.cs
@@ -3,7 +3,7 @@ using System.Data;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using DataDude.Instructions;
-using DataDude.SqlServer;
+using DataDude.Schema;
 
 [assembly: InternalsVisibleTo("DataDude.Tests")]
 
@@ -11,12 +11,9 @@ namespace DataDude
 {
     public class Dude
     {
-        private readonly ISchemaLoader _schemaLoader;
-
         public Dude(ISchemaLoader? schemaLoader = null)
         {
-            Context = new DataDudeContext();
-            _schemaLoader = schemaLoader ?? new SqlServerSchemaLoader();
+            Context = new DataDudeContext(schemaLoader ?? new SqlServer.SqlServerSchemaLoader());
         }
 
         protected DataDudeContext Context { get; }
@@ -25,7 +22,7 @@ namespace DataDude
 
         public async Task Go(IDbConnection connection, IDbTransaction? transaction = null)
         {
-            Context.Schema = await _schemaLoader.Load(connection, transaction);
+            await Context.LoadSchema(connection, transaction);
 
             foreach (var preProcessor in Context.InstructionPreProcessors)
             {

--- a/DataDude/Instructions/Insert/InsertExtensions.cs
+++ b/DataDude/Instructions/Insert/InsertExtensions.cs
@@ -45,7 +45,7 @@ namespace DataDude
 
         public static Dude ConfigureCustomColumnValue(this Dude dude, Func<ColumnInformation, ColumnValue, bool> match, Func<object> getValue)
         {
-            dude.ConfigureInsert(x => x.InsertValueProviders.Add(new CustomValueProvider(match, getValue)));
+            dude.ConfigureInsert(x => x.InsertValueProviders.Insert(0, new CustomValueProvider(match, getValue)));
             return dude;
         }
 

--- a/DataDude/Instructions/Insert/InsertInstructionHandler.cs
+++ b/DataDude/Instructions/Insert/InsertInstructionHandler.cs
@@ -47,12 +47,10 @@ namespace DataDude.Instructions.Insert
                         }
                         else
                         {
-                            throw new InsertHandlerException(
-                                $"Could not resolve a row handler for insertion of a row in {insert.TableName}",
-                                statement: statement);
+                            throw new InsertRowHandlerMissing(statement);
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (ex is not InsertRowHandlerMissing)
                     {
                         throw new InsertHandlerException($"Insertion into table {insert.TableName} failed", ex, statement);
                     }

--- a/DataDude/Instructions/Insert/Insertion/GeneratingInsertRowHandler.cs
+++ b/DataDude/Instructions/Insert/Insertion/GeneratingInsertRowHandler.cs
@@ -21,7 +21,8 @@ namespace DataDude.Instructions.Insert.Insertion
 
         public override bool CanHandleInsert(InsertStatement statement, InsertContext context) => statement.Data
             .Where(x => x.Column.IsPrimaryKey)
-            .All(x => CanHandleInsertOfPKColumn(x.Column, x.Value, context));
+            .All(x => CanHandleInsertOfPKColumn(x.Column, x.Value, context)) &&
+            statement.Data.Any(x => x.Column.IsPrimaryKey);
 
         public override async Task<InsertedRow> Insert(InsertStatement statement, InsertContext context, IDbConnection connection, IDbTransaction? transaction = null)
         {

--- a/DataDude/Instructions/Insert/Insertion/InsertRowHandlerMissing.cs
+++ b/DataDude/Instructions/Insert/Insertion/InsertRowHandlerMissing.cs
@@ -1,0 +1,10 @@
+﻿namespace DataDude.Instructions.Insert.Insertion
+{
+    public class InsertRowHandlerMissing : InsertHandlerException
+    {
+        public InsertRowHandlerMissing(InsertStatement statement)
+            : base($"Could not find an insert row handler for insert into table {statement.Table.Name}. Try configuring OutputInsertRowHandler or plug in your own insert row handler", statement: statement)
+        {
+        }
+    }
+}

--- a/DataDude/Schema/CachableSchemaLoader.cs
+++ b/DataDude/Schema/CachableSchemaLoader.cs
@@ -1,0 +1,28 @@
+﻿using System.Data;
+using System.Threading.Tasks;
+
+namespace DataDude.Schema
+{
+    public class CachableSchemaLoader : ISchemaLoader
+    {
+        private readonly ISchemaLoader _loader;
+        private SchemaInformation? _cachedSchema;
+        public CachableSchemaLoader(ISchemaLoader loader) => _loader = loader;
+
+        public bool CacheSchema
+        {
+            get => _loader.CacheSchema;
+            set => _loader.CacheSchema = value;
+        }
+
+        public async Task<SchemaInformation> Load(IDbConnection connection, IDbTransaction? transaction = null)
+        {
+            if (CacheSchema)
+            {
+                return _cachedSchema ??= await _loader.Load(connection, transaction);
+            }
+
+            return await _loader.Load(connection, transaction);
+        }
+    }
+}

--- a/DataDude/Schema/ISchemaLoader.cs
+++ b/DataDude/Schema/ISchemaLoader.cs
@@ -6,6 +6,7 @@ namespace DataDude
 {
     public interface ISchemaLoader
     {
+        bool CacheSchema { get; set; }
         Task<SchemaInformation> Load(IDbConnection connection, IDbTransaction? transaction = null);
     }
 }

--- a/DataDude/Schema/SqlServerSchemaLoader.cs
+++ b/DataDude/Schema/SqlServerSchemaLoader.cs
@@ -9,6 +9,8 @@ namespace DataDude.SqlServer
 {
     public class SqlServerSchemaLoader : ISchemaLoader
     {
+        public bool CacheSchema { get; set; } = true;
+
         public async Task<SchemaInformation> Load(IDbConnection connection, IDbTransaction? transaction = null)
         {
             var (columns, foreignKeys, triggers) = await LoadSchema(connection, transaction);


### PR DESCRIPTION
- Fixing #12 - Inserting custom configured values first
- Fixing #11 - By not letting `GeneratingInsertRowHandler` handle inserts without any PK's and improving error message when no insert-row-handlers match an insert statement
- Ability to cache schema in order to avoid unnecessary schema loading