### PR TITLE
Various bugfixes

### DIFF
--- a/DataDude.Tests/Core/Scripts/Migrations/1.0.0/01.Schema.sql
+++ b/DataDude.Tests/Core/Scripts/Migrations/1.0.0/01.Schema.sql
@@ -64,6 +64,11 @@ CREATE TABLE Test_PK_Less_Scenario(
 )
 GO
 
+CREATE TABLE Test_PK_Sequential_Uuid(
+	Id UNIQUEIDENTIFIER PRIMARY KEY NOT NULL DEFAULT(newsequentialid()),
+)
+GO
+
 CREATE TRIGGER People.EmployeeUpdatedAt ON People.Employee AFTER UPDATE AS BEGIN
 	UPDATE People.Employee 
 		SET People.Employee.UpdatedAt = GETDATE()

--- a/DataDude.Tests/Core/TestTable.cs
+++ b/DataDude.Tests/Core/TestTable.cs
@@ -8,7 +8,7 @@ namespace DataDude.Tests.Core
         public TestTable(string name)
             : this(name, "Id")
         {
-            AddIndex(new IndexInformation($"PK_{name}", new[] { this["Id"] ! }, true, false, false, false));
+            AddIndex(new IndexInformation(this, $"PK_{name}", new[] { this["Id"] ! }, true, false, false, false));
         }
 
         public TestTable(string name, params string[] columns)
@@ -25,7 +25,7 @@ namespace DataDude.Tests.Core
                     this,
                     referenceTable,
                     new[] { (this["Id"], referenceTable["Id"]) });
-                AddForeignKey(t => fk);
+                AddForeignKey(fk);
             }
 
             return this;

--- a/DataDude.Tests/Core/TestTable.cs
+++ b/DataDude.Tests/Core/TestTable.cs
@@ -8,10 +8,11 @@ namespace DataDude.Tests.Core
         public TestTable(string name)
             : this(name, "Id")
         {
+            AddIndex(new IndexInformation($"PK_{name}", new[] { this["Id"] ! }, true, false, false, false));
         }
 
         public TestTable(string name, params string[] columns)
-            : base("dbo", name, table => columns.Select(c => new ColumnInformation(table, c, "int", true, true, false, false, null, 4, 0, 0)))
+            : base("dbo", name, table => columns.Select(c => new ColumnInformation(table, c, "int", true, false, false, null, 4, 0, 0)))
         {
         }
 

--- a/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
+++ b/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
@@ -98,7 +98,7 @@ namespace DataDude.Tests.Inserts
             var a = schema.AddTable("A");
             var b = new TableInformation("dbo", "B", table => new[]
             {
-                new ColumnInformation(table, "a_Id", "int", false, false, isNullable: true, false, null, 0, 0, 0),
+                new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
             b.AddForeignKey(t => new ForeignKeyInformation("FK_B_A", t, a, new[] { (t["a_Id"], a["Id"]) }));
 

--- a/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
+++ b/DataDude.Tests/Inserts/AutoInsertFKTableTestscs.cs
@@ -77,7 +77,7 @@ namespace DataDude.Tests.Inserts
         {
             var schema = new TestSchema();
             var a = schema.AddTable("A");
-            a.AddForeignKey(t => new ForeignKeyInformation("FK_A_A", t, t, new[] { (t["Id"], t["Id"]) }));
+            a.AddForeignKey(new ForeignKeyInformation("FK_A_A", a, a, new[] { (a["Id"], a["Id"]) }));
             var b = schema.AddTable("B").AddFk(a);
 
             var context = new DataDudeContext(schema);
@@ -100,7 +100,8 @@ namespace DataDude.Tests.Inserts
             {
                 new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
-            b.AddForeignKey(t => new ForeignKeyInformation("FK_B_A", t, a, new[] { (t["a_Id"], a["Id"]) }));
+
+            b.AddForeignKey(new ForeignKeyInformation("FK_B_A", b, a, new[] { (b["a_Id"], b["Id"]) }));
 
             var context = new DataDudeContext(schema);
             await context.LoadSchema(null, null);

--- a/DataDude.Tests/Inserts/InstructionTests.cs
+++ b/DataDude.Tests/Inserts/InstructionTests.cs
@@ -242,5 +242,18 @@ namespace DataDude.Tests
             var rows = await connection.QueryFirstAsync<int>("SELECT Count(1) FROM Test_PK_Less_Scenario");
             rows.ShouldBe(1);
         }
+
+        [Fact]
+        public async Task Can_Insert_Sequential_Default_Using_Generated_Value_Instead_Of_Default()
+        {
+            using var connection = Fixture.CreateNewConnection();
+
+            await new Dude()
+                .Insert("Test_PK_Sequential_Uuid")
+                .Go(connection);
+
+            var rows = await connection.QueryFirstAsync<int>("SELECT Count(1) FROM Test_PK_Sequential_Uuid");
+            rows.ShouldBe(1);
+        }
     }
 }

--- a/DataDude.Tests/Schema/DependencyServiceTests.cs
+++ b/DataDude.Tests/Schema/DependencyServiceTests.cs
@@ -69,7 +69,7 @@ namespace DataDude.Tests.Schema
         {
             var service = new DependencyService(DependencyTraversalStrategy.FollowAllForeignKeys);
             var a = new TestTable("A");
-            a.AddForeignKey(t => new ForeignKeyInformation("FK", t, t, new[] { (t["Id"], t["Id"]) }));
+            a.AddForeignKey(new ForeignKeyInformation("FK", a, a, new[] { (a["Id"], a["Id"]) }));
 
             Should.Throw<DependencyTraversalFailedException>(() => service.GetOrderedDependenciesFor(a));
         }
@@ -79,7 +79,7 @@ namespace DataDude.Tests.Schema
         {
             var service = new DependencyService(DependencyTraversalStrategy.SkipRecursiveForeignKeys);
             var a = new TestTable("A");
-            a.AddForeignKey(t => new ForeignKeyInformation("FK", t, t, new[] { (t["Id"], t["Id"]) }));
+            a.AddForeignKey(new ForeignKeyInformation("FK", a, a, new[] { (a["Id"], a["Id"]) }));
 
             var dependencies = Should.NotThrow(() => service.GetOrderedDependenciesFor(a));
             dependencies.ShouldBeEmpty();
@@ -95,7 +95,7 @@ namespace DataDude.Tests.Schema
             {
                 new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
-            b.AddForeignKey(table => new ForeignKeyInformation("FK", table, a, new[] { (table["a_Id"], a["Id"]) }));
+            b.AddForeignKey(new ForeignKeyInformation("FK", b, a, new[] { (b["a_Id"], a["Id"]) }));
 
             var dependencies = Should.NotThrow(() => service.GetOrderedDependenciesFor(b));
             dependencies.ShouldContain(a);
@@ -111,7 +111,7 @@ namespace DataDude.Tests.Schema
             {
                 new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
-            b.AddForeignKey(table => new ForeignKeyInformation("FK", table, a, new[] { (table["a_Id"], a["Id"]) }));
+            b.AddForeignKey(new ForeignKeyInformation("FK", b, a, new[] { (b["a_Id"], a["Id"]) }));
 
             var dependencies = Should.NotThrow(() => service.GetOrderedDependenciesFor(b));
             dependencies.ShouldBeEmpty();

--- a/DataDude.Tests/Schema/DependencyServiceTests.cs
+++ b/DataDude.Tests/Schema/DependencyServiceTests.cs
@@ -93,7 +93,7 @@ namespace DataDude.Tests.Schema
             var a = new TestTable("A");
             var b = new TableInformation("dbo", "B", table => new[]
             {
-                new ColumnInformation(table, "a_Id", "int", false, false, isNullable: true, false, null, 0, 0, 0),
+                new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
             b.AddForeignKey(table => new ForeignKeyInformation("FK", table, a, new[] { (table["a_Id"], a["Id"]) }));
 
@@ -109,7 +109,7 @@ namespace DataDude.Tests.Schema
             var a = new TestTable("A");
             var b = new TableInformation("dbo", "B", table => new[]
             {
-                new ColumnInformation(table, "a_Id", "int", false, false, isNullable: true, false, null, 0, 0, 0),
+                new ColumnInformation(table, "a_Id", "int", false, isNullable: true, false, null, 0, 0, 0),
             });
             b.AddForeignKey(table => new ForeignKeyInformation("FK", table, a, new[] { (table["a_Id"], a["Id"]) }));
 

--- a/DataDude.Tests/Schema/SchemaIntegrationTests.cs
+++ b/DataDude.Tests/Schema/SchemaIntegrationTests.cs
@@ -54,6 +54,10 @@ namespace DataDude.Tests.Schema
                 referencedTable: "OfficeOccupant",
                 ("OfficeId", "OfficeId"),
                 ("EmployeeId", "EmployeeId"));
+
+            schema["Test_Generated_PK_Scenario_1"].Indexes.ShouldHaveSingleItem().ShouldSatisfyAllConditions(
+                index => index.Name.ShouldBe("PK_Test_PK_Scenarios_1"),
+                index => index.IsPrimaryKey.ShouldBeTrue());
         }
     }
 }

--- a/DataDude/Instructions/Insert/Insertion/IdentityInsertRowHandler.cs
+++ b/DataDude/Instructions/Insert/Insertion/IdentityInsertRowHandler.cs
@@ -12,14 +12,14 @@ namespace DataDude.Instructions.Insert.Insertion
     {
         public override bool CanHandleInsert(InsertStatement statement, InsertContext context)
         {
-            var primaryKeys = statement.Table.Where(x => x.IsPrimaryKey);
+            var primaryKeys = statement.Table.Where(x => x.IsPrimaryKey());
             return primaryKeys.Count() == 1 && primaryKeys.All(x => x.IsIdentity);
         }
 
         public override async Task<InsertedRow> Insert(InsertStatement statement, InsertContext context, IDbConnection connection, IDbTransaction? transaction = null)
         {
             var (columns, values, parameters) = GetInsertInformation(statement);
-            var primaryKey = statement.Table.Single(x => x.IsPrimaryKey && x.IsIdentity);
+            var primaryKey = statement.Table.Single(x => x.IsPrimaryKey() && x.IsIdentity);
             var insertedRow = await connection.QuerySingleAsync<object>(
                 $@"INSERT INTO {statement.Table.FullName}({columns}) VALUES({values})
                 SELECT * FROM {statement.Table.FullName} WHERE [{primaryKey.Name}] = SCOPE_IDENTITY()",

--- a/DataDude/Instructions/Insert/ValueProviders/ValueProvider.cs
+++ b/DataDude/Instructions/Insert/ValueProviders/ValueProvider.cs
@@ -10,7 +10,7 @@ namespace DataDude.Instructions.Insert.ValueProviders
         public void Process(ColumnInformation column, ColumnValue value)
         {
             if (column.DefaultValue is { Length: > 0 } ||
-                column.IsPrimaryKey ||
+                column.IsPrimaryKey() ||
                 column.IsIdentity ||
                 column.IsComputed ||
                 column.Table.ForeignKeys.Any(fk => fk.Columns.Any(fk_col => fk_col.Column == column)) ||
@@ -37,8 +37,7 @@ namespace DataDude.Instructions.Insert.ValueProviders
             "datetime" => DbType.DateTime,
             "datetime2" => DbType.DateTime2,
             "datetimeoffset" => DbType.DateTimeOffset,
-            "decimal" => DbType.Decimal,
-            "numeric" => DbType.VarNumeric,
+            "decimal" or "numeric" => DbType.Decimal,
             "float" => DbType.Double,
             "uniqueidentifier" => DbType.Guid,
             "smallint" => DbType.Int16,

--- a/DataDude/Schema/ColumnInformation.cs
+++ b/DataDude/Schema/ColumnInformation.cs
@@ -1,4 +1,7 @@
-﻿namespace DataDude.Schema
+﻿using System;
+using System.Linq;
+
+namespace DataDude.Schema
 {
     public class ColumnInformation
     {
@@ -6,7 +9,6 @@
             TableInformation table,
             string name,
             string dataType,
-            bool isPrimaryKey,
             bool isIdentity,
             bool isNullable,
             bool isComputed,
@@ -18,7 +20,6 @@
             Table = table;
             Name = name;
             DataType = dataType;
-            IsPrimaryKey = isPrimaryKey;
             IsIdentity = isIdentity;
             IsNullable = isNullable;
             IsComputed = isComputed;
@@ -31,7 +32,6 @@
         public TableInformation Table { get; }
         public string Name { get; }
         public string DataType { get; } = default!;
-        public bool IsPrimaryKey { get; }
         public bool IsIdentity { get; }
         public bool IsNullable { get; }
         public bool IsComputed { get; }
@@ -39,5 +39,8 @@
         public int MaxLength { get; }
         public int Precision { get; }
         public int Scale { get; }
+        public bool IsPrimaryKey() => Table.Indexes
+            .Where(x => x.IsPrimaryKey)
+            .Any(index => index.Columns.Contains(this));
     }
 }

--- a/DataDude/Schema/DependencyService.cs
+++ b/DataDude/Schema/DependencyService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace DataDude.Schema

--- a/DataDude/Schema/IndexInformation.cs
+++ b/DataDude/Schema/IndexInformation.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace DataDude.Schema
+{
+    [DebuggerDisplay("{Name}")]
+    public class IndexInformation
+    {
+        public IndexInformation(string name, IEnumerable<ColumnInformation> columns, bool isPrimaryKey, bool isUnique, bool isUniqueConstraint, bool isDisabled)
+        {
+            Name = name;
+            Columns = columns;
+            IsPrimaryKey = isPrimaryKey;
+            IsUnique = isUnique;
+            IsUniqueConstraint = isUniqueConstraint;
+            IsDisabled = isDisabled;
+        }
+
+        public string Name { get; }
+        public IEnumerable<ColumnInformation> Columns { get; }
+        public bool IsPrimaryKey { get; }
+        public bool IsUnique { get; }
+        public bool IsUniqueConstraint { get; }
+        public bool IsDisabled { get; }
+    }
+}

--- a/DataDude/Schema/IndexInformation.cs
+++ b/DataDude/Schema/IndexInformation.cs
@@ -6,8 +6,9 @@ namespace DataDude.Schema
     [DebuggerDisplay("{Name}")]
     public class IndexInformation
     {
-        public IndexInformation(string name, IEnumerable<ColumnInformation> columns, bool isPrimaryKey, bool isUnique, bool isUniqueConstraint, bool isDisabled)
+        public IndexInformation(TableInformation table, string name, IEnumerable<ColumnInformation> columns, bool isPrimaryKey, bool isUnique, bool isUniqueConstraint, bool isDisabled)
         {
+            Table = table;
             Name = name;
             Columns = columns;
             IsPrimaryKey = isPrimaryKey;
@@ -16,6 +17,7 @@ namespace DataDude.Schema
             IsDisabled = isDisabled;
         }
 
+        public TableInformation Table { get; }
         public string Name { get; }
         public IEnumerable<ColumnInformation> Columns { get; }
         public bool IsPrimaryKey { get; }

--- a/DataDude/Schema/SqlServerSchemaLoader.cs
+++ b/DataDude/Schema/SqlServerSchemaLoader.cs
@@ -51,6 +51,7 @@ namespace DataDude.SqlServer
                 }
 
                 table.AddIndex(new IndexInformation(
+                    table,
                     indexName,
                     indexColumns!,
                     group.Key.IsPrimaryKey,
@@ -71,7 +72,7 @@ namespace DataDude.SqlServer
                 }
 
                 var fkColumns = GetForeignKeyColumns(constraintName, table, referenceTable, group);
-                table.AddForeignKey(table => new ForeignKeyInformation(group.Key.ConstraintName, table, referenceTable, fkColumns));
+                table.AddForeignKey(new ForeignKeyInformation(group.Key.ConstraintName, table, referenceTable, fkColumns));
             }
 
             foreach (var group in triggers.GroupBy(x => (x.SchemaName, x.TableName)))
@@ -84,7 +85,7 @@ namespace DataDude.SqlServer
 
                 foreach (var trigger in group)
                 {
-                    table.AddTrigger(new TriggerInformation(trigger.Name, trigger.IsDisabled));
+                    table.AddTrigger(new TriggerInformation(table, trigger.Name, trigger.IsDisabled));
                 }
             }
 

--- a/DataDude/Schema/TableInformation.cs
+++ b/DataDude/Schema/TableInformation.cs
@@ -12,6 +12,7 @@ namespace DataDude.Schema
         private readonly IDictionary<string, ColumnInformation> _columns;
         private readonly IList<ForeignKeyInformation> _foreignKeys;
         private readonly IList<TriggerInformation> _triggers;
+        private readonly IList<IndexInformation> _indexes;
         public TableInformation(string schema, string name, Func<TableInformation, IEnumerable<ColumnInformation>> getColumns)
         {
             Schema = schema;
@@ -19,6 +20,7 @@ namespace DataDude.Schema
             _columns = getColumns(this).ToDictionary(x => x.Name, x => x);
             _foreignKeys = new List<ForeignKeyInformation>();
             _triggers = new List<TriggerInformation>();
+            _indexes = new List<IndexInformation>();
         }
 
         public string Schema { get; }
@@ -26,11 +28,13 @@ namespace DataDude.Schema
         public string FullName => $"[{Schema}].[{Name}]";
         public IEnumerable<ForeignKeyInformation> ForeignKeys => _foreignKeys;
         public IEnumerable<TriggerInformation> Triggers => _triggers;
+        public IEnumerable<IndexInformation> Indexes => _indexes;
         public ColumnInformation? this[string name] => _columns.TryGetValue(name, out var column) ? column : null;
         public IEnumerator<ColumnInformation> GetEnumerator() => _columns.Values.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         public void AddForeignKey(Func<TableInformation, ForeignKeyInformation> getFk) => _foreignKeys.Add(getFk(this));
         public void AddTrigger(TriggerInformation trigger) => _triggers.Add(trigger);
+        public void AddIndex(IndexInformation index) => _indexes.Add(index);
 
         public override string ToString() => Name;
     }

--- a/DataDude/Schema/TableInformation.cs
+++ b/DataDude/Schema/TableInformation.cs
@@ -32,7 +32,7 @@ namespace DataDude.Schema
         public ColumnInformation? this[string name] => _columns.TryGetValue(name, out var column) ? column : null;
         public IEnumerator<ColumnInformation> GetEnumerator() => _columns.Values.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        public void AddForeignKey(Func<TableInformation, ForeignKeyInformation> getFk) => _foreignKeys.Add(getFk(this));
+        public void AddForeignKey(ForeignKeyInformation foreignKey) => _foreignKeys.Add(foreignKey);
         public void AddTrigger(TriggerInformation trigger) => _triggers.Add(trigger);
         public void AddIndex(IndexInformation index) => _indexes.Add(index);
 

--- a/DataDude/Schema/TriggerInformation.cs
+++ b/DataDude/Schema/TriggerInformation.cs
@@ -2,12 +2,14 @@
 {
     public class TriggerInformation
     {
-        public TriggerInformation(string name, bool isDisabled)
+        public TriggerInformation(TableInformation table, string name, bool isDisabled)
         {
+            Table = table;
             Name = name;
             IsDisabled = isDisabled;
         }
 
+        public TableInformation Table { get; }
         public string Name { get; }
         public bool IsDisabled { get; }
     }


### PR DESCRIPTION
Some changes and fixes:
- `DEFAULT(newsequentialid())` would cause exception because it cannot be used in a select statement, so instead defaulting to code generated guid which is not sequential... but `¯\_(ツ)_/¯`
- Schema loading could generate column duplicates when a column belonged to multiple indexes:
  - Removed column property `IsPrimaryKey`
  - Added table collection `Indexes`
  - Added column method `IsPrimaryKey()` which checks table indexes
- `numeric` data type is now mapped to `DbType.Decimal` (for null values) instead of `DbType.VarNumeric`