### PR TITLE
Handling of multiple go statements

### DIFF
--- a/DataDude/DataDude.csproj
+++ b/DataDude/DataDude.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/DataDude/Instructions/Insert/AutomaticForeignKeys/AddMissingInsertInstructionsPreProcessor.cs
+++ b/DataDude/Instructions/Insert/AutomaticForeignKeys/AddMissingInsertInstructionsPreProcessor.cs
@@ -21,8 +21,10 @@ namespace DataDude.Instructions.Insert.AutomaticForeignKeys
             {
                 if (context.Schema?[instruction.TableName] is { } table)
                 {
+                    IEnumerable<InsertedRow> insertedRows = InsertContext.Get(context)?.InsertedRows ?? Array.Empty<InsertedRow>();
                     var dependencies = _dependencyService.GetOrderedDependenciesFor(table)
                         .Where(t => !toInsert.Values.Any(x => x.Contains(t)))
+                        .Where(t => !insertedRows.Any(x => x.Table == t))
                         .ToList();
 
                     toInsert.Add(instruction, new InsertInformation(table, dependencies));


### PR DESCRIPTION
Fixes #20 
Fixes #19 

Done:
- Auto Insert FK's logic will now take previously inserted rows into account and not insert dependencies that have already been inserted. 
- `EnableAutomaticForeignKeys` can now safely be called multiple times
- `DisableAutomaticForeignKeys` method added in order to turn off configured Auto FK behavior